### PR TITLE
Update alsa to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ libc = { version = "0.2.21", optional = true }
 winrt = { version = "0.7.0", optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.4.3"
-nix = "0.15"
+alsa = "0.5.0"
+nix = "0.20"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Since nix that is dependency crate is old version, midir cannot build for riscv64gc.

riscv64gc support is added by nix 0.18. So I would like to update alsa to 0.5.0