### PR TITLE
update alsa to 0.6, nix to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ libc = { version = "0.2.21", optional = true }
 winrt = { version = "0.7.0", optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.4.3"
-nix = "0.15"
+alsa = "0.6"
+nix = "0.23"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -651,11 +651,11 @@ fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T
         // If here, there should be data.
         let mut ev = match seq_input.event_input() {
             Ok(ev) => ev,
-            Err(ref e) if e.errno() == Some(self::nix::errno::Errno::ENOSPC) => {
+            Err(ref e) if e.errno() == self::nix::errno::Errno::ENOSPC => {
                 let _ = writeln!(stderr(), "\nError in handle_input: ALSA MIDI input buffer overrun!\n");
                 continue;
             },
-            Err(ref e) if e.errno() == Some(self::nix::errno::Errno::EAGAIN) => {
+            Err(ref e) if e.errno() == self::nix::errno::Errno::EAGAIN => {
                 let _ = writeln!(stderr(), "\nError in handle_input: no input event from ALSA MIDI input buffer!\n");
                 continue;
             },


### PR DESCRIPTION
in order to support riscv.
supersedes https://github.com/mozilla/midir/pull/2, in line with https://github.com/msirringhaus/minidump_writer_linux/pull/10