### PR TITLE
Upgrade bitflags to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ license = "MIT"
 [features]
 default = []
 avoid_timestamping = []
-jack = ["jack-sys", "libc"]
+jack = ["jack-sys", "libc", "bitflags"]
 
 [dependencies]
-bitflags = "1.2"
+bitflags = { version = "2", optional = true }
 memalloc = "0.1.0"
 jack-sys = { version = "0.1.0", optional = true }
 libc = { version = "0.2.21", optional = true }

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -40,6 +40,7 @@ use super::jack_sys::{
 pub const JACK_DEFAULT_MIDI_TYPE: &[u8] = b"8 bit raw midi\0";
 
 bitflags! {
+    #[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
     pub struct JackOpenOptions: u32 {
         const NoStartServer = 1;
         const UseExactName = 2;
@@ -49,6 +50,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
     pub struct PortFlags: u32 {
         const PortIsInput = 1;
         const PortIsOutput = 2;


### PR DESCRIPTION
And while here, make it optional since only the jack backend requires it.